### PR TITLE
Add TryGetFromExternalString when getting ShardId

### DIFF
--- a/src/Extensions/QueryExtensions.cs
+++ b/src/Extensions/QueryExtensions.cs
@@ -11,9 +11,28 @@ public static class QueryExtensions
     /// <returns>Int16 shard Id.</returns>
     public static short ShardId(this GrainId grainId)
     {
+        if (TryGetFromExternalString(grainId, out var externalKeyShardId))
+        {
+            return externalKeyShardId;
+        }
+
         var gk = new GhostShardKey(grainId.Key.Value);
         var shardKey = gk.GetShardId();
         return shardKey;
     }
 
+    private static bool TryGetFromExternalString(GrainId grainId, out short shardId)
+    {
+        try
+        {
+            var shardKey = ShardKey<string>.FromExternalString(grainId.Key.ToString());
+            shardId = shardKey.ShardId;
+            return true;
+        }
+        catch
+        {
+            shardId = -1;
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
When getting ShardId from a GrainId, check to see if the ShardId is an ExternalString first